### PR TITLE
Menu?

### DIFF
--- a/src/Element.elm
+++ b/src/Element.elm
@@ -1,6 +1,6 @@
-module Element exposing (Element, px, styled)
+module Element exposing (Element, none, px, styled)
 
-import Html exposing (Attribute, Html)
+import Html exposing (Attribute, Html, text)
 import Html.Attributes exposing (style)
 
 
@@ -17,3 +17,8 @@ styled el css =
 px : Int -> String
 px x =
     String.fromInt x ++ "px"
+
+
+none : Html msg
+none =
+    text ""

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -118,7 +118,7 @@ type Msg
     | ArmRandomCells (List Int)
     | ClearActiveCell
     | SetDifficulty Difficulty
-    | ClickSetDifficultyFace
+    | OpenMenu Menu
 
 
 generateRandomInts : Int -> Grid -> Cmd Msg
@@ -277,8 +277,8 @@ update msg model =
             , Cmd.none
             )
 
-        ClickSetDifficultyFace ->
-            ( { model | menu = Just DifficultyMenu }
+        OpenMenu menu ->
+            ( { model | menu = Just menu }
             , Cmd.none
             )
 
@@ -433,7 +433,7 @@ viewHeader pressingFace hasActiveCell remainingFlags time mode =
             , style "width" "26px"
             , style "height" "26px"
             , style "cursor" "default"
-            , onClick ClickSetDifficultyFace
+            , onClick (OpenMenu DifficultyMenu)
             , onMouseDown (PressingFace False)
             , onMouseUp (PressingFace False)
             , onMouseOut (PressingFace False)

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -639,14 +639,12 @@ raisedDiv =
 
 modalView : Model -> Html Msg
 modalView model =
-    div []
-        [ div maskStyle
-            [ div modalStyle
-                [ h1 [] [ text "Please select a difficulty level" ]
-                , radiobutton "Beginner" Beginner model.game
-                , radiobutton "Intermediate" Intermediate model.game
-                , radiobutton "Expert" Expert model.game
-                ]
+    div maskStyle
+        [ div modalStyle
+            [ h1 [] [ text "Please select a difficulty level" ]
+            , radiobutton "Beginner" Beginner model.game
+            , radiobutton "Intermediate" Intermediate model.game
+            , radiobutton "Expert" Expert model.game
             ]
         ]
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -651,14 +651,21 @@ modalView : Model -> Html Msg
 modalView model =
     div maskStyle
         [ modalContent []
-            [ windowsChrome [ style "padding" "18px" ]
-                [ p [] [ text "Please select a difficulty level" ]
-                , radiobutton "Beginner" Beginner model.game
-                , radiobutton "Intermediate" Intermediate model.game
-                , radiobutton "Expert" Expert model.game
+            [ windowsChrome [ style "padding" "0 18px 18px" ]
+                [ formGroup "Difficulty"
+                    [ radiobutton "Beginner" Beginner model.game
+                    , radiobutton "Intermediate" Intermediate model.game
+                    , radiobutton "Expert" Expert model.game
+                    ]
                 ]
             ]
         ]
+
+
+formGroup : String -> List (Html msg) -> Html msg
+formGroup title children =
+    div []
+        (p [] [ text title ] :: children)
 
 
 maskStyle : List (Html.Attribute msg)

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -323,14 +323,6 @@ view model =
                 , ( "font-family", "Tahoma" )
                 ]
 
-        chrome =
-            styled div
-                [ ( "position", "absolute" )
-                , ( "top", "48px" )
-                , ( "left", "96px" )
-                , ( "border", "3px solid #135ddf" )
-                ]
-
         frame =
             styled raisedDiv
                 [ ( "display", "inline-block" )
@@ -380,13 +372,16 @@ view model =
             styled div
                 [ ( "width", "100%" )
                 , ( "height", "24px" )
-                , ( "background", "#ece9d8" )
                 , ( "display", "flex" )
                 , ( "align-items", "center" )
                 ]
     in
     background []
-        [ chrome []
+        [ windowsChrome
+            [ style "position" "absolute"
+            , style "top" "48px"
+            , style "left" "96px"
+            ]
             [ viewToolbar []
                 [ toolbarBtn [ onClick (OpenMenu DifficultyMenu) ] [ text "Game" ]
                 ]
@@ -655,11 +650,13 @@ raisedDiv =
 modalView : Model -> Html Msg
 modalView model =
     div maskStyle
-        [ div modalStyle
-            [ h1 [] [ text "Please select a difficulty level" ]
-            , radiobutton "Beginner" Beginner model.game
-            , radiobutton "Intermediate" Intermediate model.game
-            , radiobutton "Expert" Expert model.game
+        [ modalContent []
+            [ windowsChrome [ style "padding" "18px" ]
+                [ p [] [ text "Please select a difficulty level" ]
+                , radiobutton "Beginner" Beginner model.game
+                , radiobutton "Intermediate" Intermediate model.game
+                , radiobutton "Expert" Expert model.game
+                ]
             ]
         ]
 
@@ -675,32 +672,40 @@ maskStyle =
     ]
 
 
-modalStyle : List (Html.Attribute msg)
-modalStyle =
-    [ style "background-color" "rgba(255,255,255,1.0)"
-    , style "position" "absolute"
-    , style "top" "50%"
-    , style "left" "50%"
-    , style "height" "auto"
-    , style "max-height" "80%"
-    , style "width" "700px"
-    , style "max-width" "95%"
-    , style "padding" "10px"
-    , style "border-radius" "3px"
-    , style "box-shadow" "1px 1px 5px rgba(0,0,0,0.5)"
-    , style "transform" "translate(-50%, -50%)"
-    ]
+modalContent : Element msg
+modalContent =
+    styled div
+        [ ( "position", "absolute" )
+        , ( "top", "50%" )
+        , ( "left", "50%" )
+        , ( "height", "auto" )
+        , ( "max-height", "80%" )
+        , ( "width", "400px" )
+        , ( "max-width", "95%" )
+        , ( "padding", "10px" )
+        , ( "border-radius", "3px" )
+        , ( "transform", "translate(-50%, -50%)" )
+        ]
 
 
 radiobutton : String -> Difficulty -> Difficulty -> Html Msg
 radiobutton value difficulty currentGameDifficulty =
-    label []
+    label [ style "display" "flex", style "align-items" "center" ]
         [ input
             [ type_ "radio"
             , name "value"
             , onClick (SetDifficulty difficulty)
             , checked (difficulty == currentGameDifficulty)
+            , style "margin" "4px 8px"
             ]
             []
         , text value
+        ]
+
+
+windowsChrome : Element msg
+windowsChrome =
+    styled div
+        [ ( "border", "3px solid #135ddf" )
+        , ( "background", "#ece9d8" )
         ]

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -6,7 +6,7 @@ import Browser
 import Element exposing (Element, px, styled)
 import GameMode exposing (GameMode(..))
 import Grid exposing (Cell, CellState(..), Grid)
-import Html exposing (Html, div, h1, input, label, text)
+import Html exposing (Html, button, div, h1, input, label, p, text)
 import Html.Attributes exposing (checked, name, style, type_)
 import Html.Events exposing (custom, onClick, onMouseDown, onMouseEnter, onMouseLeave, onMouseOut, onMouseUp)
 import Json.Decode as Json
@@ -320,6 +320,15 @@ view model =
                 , ( "width", "100%" )
                 , ( "overflow", "hidden" )
                 , ( "background-image", "url('./images/windows_xp_bliss-wide.jpg')" )
+                , ( "font-family", "Tahoma" )
+                ]
+
+        chrome =
+            styled div
+                [ ( "position", "absolute" )
+                , ( "top", "48px" )
+                , ( "left", "96px" )
+                , ( "border", "3px solid #135ddf" )
                 ]
 
         frame =
@@ -327,9 +336,6 @@ view model =
                 [ ( "display", "inline-block" )
                 , ( "background-color", "#bdbdbd" )
                 , ( "padding", "5px" )
-                , ( "position", "absolute" )
-                , ( "top", "48px" )
-                , ( "left", "96px" )
                 ]
 
         hasActiveCell : Bool
@@ -360,11 +366,38 @@ view model =
 
                 Nothing ->
                     Element.none
+
+        toolbarBtn =
+            styled button
+                [ ( "background", "none" )
+                , ( "border", "none" )
+                , ( "padding", "0 8px" )
+                , ( "outline", "0" )
+                , ( "font-size", "14px" )
+                ]
+
+        viewToolbar =
+            styled div
+                [ ( "width", "100%" )
+                , ( "height", "24px" )
+                , ( "background", "#ece9d8" )
+                , ( "display", "flex" )
+                , ( "align-items", "center" )
+                ]
     in
     background []
-        [ frame []
-            [ viewHeader model.pressingFace hasActiveCell (getBombCount model.game - flaggedCount) model.time model.mode
-            , viewGrid model.activeCell model.mode unexposedNeighbors model.grid
+        [ chrome []
+            [ viewToolbar []
+                [ toolbarBtn [ onClick (OpenMenu DifficultyMenu) ] [ text "Game" ]
+                ]
+            , frame []
+                [ viewHeader model.pressingFace
+                    hasActiveCell
+                    (getBombCount model.game - flaggedCount)
+                    model.time
+                    model.mode
+                , viewGrid model.activeCell model.mode unexposedNeighbors model.grid
+                ]
             ]
         , menu
         ]
@@ -390,10 +423,6 @@ viewHeader pressingFace hasActiveCell remainingFlags time mode =
             else
                 Bitmap.forFace Smile
 
-        newGameFaceDiv : Element msg
-        newGameFaceDiv =
-            Bitmap.forFace SetDifficultyFace
-
         header =
             styled insetDiv
                 [ ( "display", "flex" )
@@ -415,26 +444,12 @@ viewHeader pressingFace hasActiveCell remainingFlags time mode =
             )
         , faceDiv
             [ style "display" "flex"
-            , style "display" "flex"
             , style "justify-content" "center"
             , style "width" "26px"
             , style "height" "26px"
             , style "cursor" "default"
             , onClick ClickFace
             , onMouseDown (PressingFace True)
-            , onMouseUp (PressingFace False)
-            , onMouseOut (PressingFace False)
-            ]
-            []
-        , newGameFaceDiv
-            [ style "display" "flex"
-            , style "display" "flex"
-            , style "justify-content" "center"
-            , style "width" "26px"
-            , style "height" "26px"
-            , style "cursor" "default"
-            , onClick (OpenMenu DifficultyMenu)
-            , onMouseDown (PressingFace False)
             , onMouseUp (PressingFace False)
             , onMouseOut (PressingFace False)
             ]


### PR DESCRIPTION
instead of looking at `isDifficultySet` to decide between showing a menu or rendering the game, we now track a `Maybe Menu`. `Menu` is a new type that consists of a single constructor, `DifficultyMenu`.

before, you could have a `Model` like

```elm
{
  isDifficultySet = False
, game = Beginner
  ...
}
```

which kinda contradicts itself since there's a `Difficulty` right there! now, we just _might_ have a `Menu`. we're now always rendering the game and rendering a menu if we've got one. this seems more windows-y.

we also now have a `Msg` constructor that looks like `OpenMenu Menu`. we could open _any_ `Menu` with this. for now, we just have `DifficultyMenu`, but this all opens the door to [other potential menus](https://www.johnweeks.com/tour/mines/minesweeper-high-scores-2013-06-09.png).

otherwise, this is just a bunch of css changes. i added a toolbar to the window and made the menu look more windows-y. it's not gonna fool anyone, but i think it's a good step in the right direction.

<img width="783" alt="Screen Shot 2019-12-31 at 3 04 05 PM" src="https://user-images.githubusercontent.com/820696/71632996-983c2000-2bdf-11ea-846a-36128304fdef.png">

cc @BKSpurgeon 